### PR TITLE
Standardize plugin metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IDERP 2.0 - Custom ERPNext App per Gestione Metrature
+# iderp 2.0 - Custom ERPNext App per Gestione Metrature
 
 App personalizzata per ERPNext 15 che gestisce prodotti venduti al metro quadro, metro lineare o cadauno, con sistema avanzato di prezzi per gruppi cliente e articoli opzionali.
 

--- a/config/desktop.py
+++ b/config/desktop.py
@@ -1,7 +1,7 @@
 # config/desktop.py
 """
-IDERP Desktop Configuration for ERPNext 15
-Configurazione icone e workspace per IDERP
+iderp Desktop Configuration for ERPNext 15
+Configurazione icone e workspace per iderp
 """
 
 from frappe import _
@@ -9,7 +9,7 @@ from frappe import _
 # Configurazione base app
 app_icon = "fa fa-print"
 app_color = "#3498db"
-app_email = "ai@idstudio.org"
+app_email = "dev@idstudio.org"
 app_license = "MIT"
 
 def get_data():
@@ -17,11 +17,11 @@ def get_data():
     Return desktop icons configuration per ERPNext 15
     """
     return [
-        # Main IDERP workspace
+        # Main iderp workspace
         {
-            "module_name": "IDERP",
+            "module_name": "iderp",
             "category": "Modules",
-            "label": _("IDERP - Stampa Digitale"),
+            "label": _("iderp - Stampa Digitale"),
             "color": "#3498db",
             "icon": "fa fa-print",
             "type": "module",
@@ -51,8 +51,8 @@ def get_data():
         
         # Reports section
         {
-            "module_name": "IDERP Reports",
-            "label": _("IDERP Reports"),
+            "module_name": "iderp Reports",
+            "label": _("iderp Reports"),
             "color": "#9b59b6",
             "icon": "fa fa-bar-chart",
             "type": "module",
@@ -116,7 +116,7 @@ def get_workspace_sidebar_items():
             "items": [
                 {
                     "type": "report",
-                    "name": "IDERP Pricing Analysis",
+                    "name": "iderp Pricing Analysis",
                     "label": _("Pricing Analysis"),
                     "is_query_report": True
                 },
@@ -133,7 +133,7 @@ def get_workspace_sidebar_items():
 # Gestione permessi per workspace
 def has_permission(user=None):
     """
-    Check if user has permission to access IDERP workspace
+    Check if user has permission to access iderp workspace
     """
     import frappe
     
@@ -153,7 +153,7 @@ def has_permission(user=None):
 # Cards per dashboard
 def get_dashboard_cards():
     """
-    Return dashboard cards for IDERP workspace
+    Return dashboard cards for iderp workspace
     """
     return [
         {
@@ -189,7 +189,7 @@ def get_dashboard_cards():
 # Shortcuts per toolbar
 def get_quick_shortcuts():
     """
-    Return quick shortcuts for IDERP
+    Return quick shortcuts for iderp
     """
     return [
         {
@@ -220,8 +220,8 @@ def get_quick_shortcuts():
 
 # Configuration per menu principal
 workspace_config = {
-    "name": "IDERP",
-    "title": _("IDERP - Stampa Digitale"),
+    "name": "iderp",
+    "title": _("iderp - Stampa Digitale"),
     "icon": "fa fa-print",
     "color": "#3498db",
     "description": _("Sistema completo per gestione stampa digitale con calcoli automatici metro quadrato, metro lineare e al pezzo"),

--- a/hooks.py
+++ b/hooks.py
@@ -1,10 +1,10 @@
 # hooks.py (ROOT)
 
 app_name = "iderp"
-app_title = "IDERP - Sistema Stampa Digitale"
-app_publisher = "idstudio AI"
+app_title = "iderp - Sistema Stampa Digitale"
+app_publisher = "idstudio"
 app_description = "Plugin ERPNext per stampa digitale con calcoli universali Metro Quadrato/Lineare/Pezzo"
-app_email = "ai@idstudio.org"
+app_email = "dev@idstudio.org"
 app_license = "MIT"
 app_version = "2.0.0"
 
@@ -211,7 +211,7 @@ timezone = "Europe/Rome"
 #         ]
 #     })
 
-# Error logging specifico IDERP
+# Error logging specifico iderp
 log_clearing_doctypes = {
     "Error Log": 30  # Mantieni 30 giorni di log errori
 }
@@ -219,19 +219,19 @@ log_clearing_doctypes = {
 # Translation
 default_mail_footer = """
 <div style="text-align: center; margin-top: 20px; color: #888;">
-    <small>Powered by IDERP - Sistema Stampa Digitale v{version}</small>
+    <small>Powered by iderp - Sistema Stampa Digitale v{version}</small>
 </div>
 """.format(version=app_version)
 
 # Data Import Templates
 data_import_tool = [
     {
-        "module": "IDERP",
+        "module": "iderp",
         "doctype": "Item",
         "template": "iderp_item_template.xlsx"
     },
     {
-        "module": "IDERP", 
+        "module": "iderp", 
         "doctype": "Customer",
         "template": "iderp_customer_template.xlsx"
     }
@@ -256,7 +256,7 @@ benchmarks = {
 }
 
 def boot_session(bootinfo):
-    """Add IDERP data to boot session"""
+    """Add iderp data to boot session"""
     if frappe.session.user != "Guest":
         try:
             bootinfo.iderp = {
@@ -264,11 +264,11 @@ def boot_session(bootinfo):
                 "system_status": get_system_status()
             }
         except Exception:
-            # Don't break boot if IDERP has issues
+            # Don't break boot if iderp has issues
             pass
 
 def get_system_status():
-    """Get IDERP system status for client"""
+    """Get iderp system status for client"""
     try:
         configured_items = frappe.db.count("Item", {"supports_custom_measurement": 1})
         customer_groups = frappe.db.count("Customer Group", 

--- a/iderp.egg-info/PKG-INFO
+++ b/iderp.egg-info/PKG-INFO
@@ -3,8 +3,8 @@ Name: iderp
 Version: 0.0.1
 Summary: Custom fields and item sync for ERPNext
 Home-page: UNKNOWN
-Author: idstudio AI
-Author-email: ai@idstudio.org
+Author: idstudio
+Author-email: dev@idstudio.org
 License: UNKNOWN
 Platform: UNKNOWN
 License-File: LICENSE

--- a/iderp/__init__.py
+++ b/iderp/__init__.py
@@ -1,6 +1,6 @@
 # iderp/__init__.py zzz
 """
-IDERP Module Initialization
+iderp Module Initialization
 Sistema Stampa Digitale per ERPNext 15
 """
 
@@ -33,10 +33,10 @@ except ImportError:
 
 # Module metadata
 app_name = "iderp"
-app_title = "IDERP - Sistema Stampa Digitale"
-app_publisher = "idstudio AI"
+app_title = "iderp - Sistema Stampa Digitale"
+app_publisher = "idstudio"
 app_description = "Plugin ERPNext per stampa digitale con calcoli universali"
-app_email = "ai@idstudio.org"
+app_email = "dev@idstudio.org"
 app_license = "MIT"
 
 # ERPNext 15 compatibility flags
@@ -68,19 +68,19 @@ def validate_dependencies():
     # Check Frappe version
     frappe_version = frappe.__version__
     if not frappe_version.startswith(('15.', '16.', '17.')):
-        frappe.throw(f"IDERP requires Frappe 15+. Current version: {frappe_version}")
+        frappe.throw(f"iderp requires Frappe 15+. Current version: {frappe_version}")
     
     # Check ERPNext installation
     try:
         import erpnext
         erpnext_version = erpnext.__version__
         if not erpnext_version.startswith(('15.', '16.', '17.')):
-            frappe.throw(f"IDERP requires ERPNext 15+. Current version: {erpnext_version}")
+            frappe.throw(f"iderp requires ERPNext 15+. Current version: {erpnext_version}")
     except ImportError:
-        frappe.throw("ERPNext is required for IDERP")
+        frappe.throw("ERPNext is required for iderp")
 
 def check_installation():
-    """Check if IDERP is properly installed"""
+    """Check if iderp is properly installed"""
     import frappe
     
     required_doctypes = [
@@ -118,7 +118,7 @@ def check_installation():
     return {
         "installed": len(missing_fields) == 0,
         "missing_fields": missing_fields,
-        "message": "IDERP is properly installed" if len(missing_fields) == 0 else f"Missing fields: {', '.join(missing_fields)}"
+        "message": "iderp is properly installed" if len(missing_fields) == 0 else f"Missing fields: {', '.join(missing_fields)}"
     }
 
 def get_system_status():
@@ -161,7 +161,7 @@ def get_system_status():
 
 # Boot function for client-side
 def boot_session(bootinfo):
-    """Add IDERP data to boot session"""
+    """Add iderp data to boot session"""
     import frappe
     
     try:
@@ -172,5 +172,5 @@ def boot_session(bootinfo):
                 "system_status": get_system_status()
             }
     except Exception:
-        # Don't break boot if IDERP has issues
+        # Don't break boot if iderp has issues
         pass

--- a/iderp/api/item.py
+++ b/iderp/api/item.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/api/machine.py
+++ b/iderp/api/machine.py
@@ -2,7 +2,7 @@
 
 """
 API per comunicazione con macchine stampa
-Sistema produzione IDERP - ERPNext 15
+Sistema produzione iderp - ERPNext 15
 """
 
 import frappe

--- a/iderp/api/optional.py
+++ b/iderp/api/optional.py
@@ -2,7 +2,7 @@
 
 """
 API REST per gestione optional
-Sistema stampa digitale IDERP - ERPNext 15
+Sistema stampa digitale iderp - ERPNext 15
 """
 
 import frappe

--- a/iderp/api/production.py
+++ b/iderp/api/production.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/copy_fields.py
+++ b/iderp/copy_fields.py
@@ -16,7 +16,7 @@ def copy_custom_fields(doc, method=None):
         return
     
     try:
-        frappe.logger().info(f"[IDERP] copy_custom_fields attivato per {doc.doctype}: {doc.name}")
+        frappe.logger().info(f"[iderp] copy_custom_fields attivato per {doc.doctype}: {doc.name}")
         
         # Processa ogni item
         for item in doc.items:
@@ -28,13 +28,13 @@ def copy_custom_fields(doc, method=None):
                 apply_universal_calculations(doc, item)
                 
             except Exception as e:
-                frappe.logger().error(f"[IDERP] Errore processing item {item.item_code}: {str(e)}")
+                frappe.logger().error(f"[iderp] Errore processing item {item.item_code}: {str(e)}")
                 continue
         
-        frappe.logger().info(f"[IDERP] copy_custom_fields completato per {doc.name}")
+        frappe.logger().info(f"[iderp] copy_custom_fields completato per {doc.name}")
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore copy_custom_fields: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore copy_custom_fields: {str(e)}")
 
 def copy_fields_from_previous_document(item):
     """
@@ -93,10 +93,10 @@ def copy_fields_from_previous_document(item):
                     copied_count += 1
         
         if copied_count > 0:
-            frappe.logger().info(f"[IDERP] Copiati {copied_count} campi da {linked_doc_type} per {item.item_code}")
+            frappe.logger().info(f"[iderp] Copiati {copied_count} campi da {linked_doc_type} per {item.item_code}")
             
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore copia campi: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore copia campi: {str(e)}")
 
 def apply_universal_calculations(doc, item):
     """
@@ -105,7 +105,7 @@ def apply_universal_calculations(doc, item):
     try:
         # Skip se prezzo è bloccato manualmente
         if getattr(item, 'price_locked', 0):
-            frappe.logger().info(f"[IDERP] Skip calcolo {item.item_code} - prezzo bloccato")
+            frappe.logger().info(f"[iderp] Skip calcolo {item.item_code} - prezzo bloccato")
             return
         
         # Skip se già calcolato automaticamente per evitare loop
@@ -130,7 +130,7 @@ def apply_universal_calculations(doc, item):
             calculate_item_price_server_side(doc, item, tipo_vendita, qty_info)
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore calcolo universale: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore calcolo universale: {str(e)}")
 
 def calculate_item_quantities(item, tipo_vendita):
     """
@@ -186,7 +186,7 @@ def calculate_item_quantities(item, tipo_vendita):
         return None
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore calcolo quantità: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore calcolo quantità: {str(e)}")
         return None
 
 def update_calculated_fields(item, qty_info, tipo_vendita):
@@ -204,10 +204,10 @@ def update_calculated_fields(item, qty_info, tipo_vendita):
         elif tipo_vendita == "Pezzo":
             item.pz_totali = int(qty_info['total_qty'])
         
-        frappe.logger().debug(f"[IDERP] Campi aggiornati per {tipo_vendita}: {qty_info['total_qty']:.3f} {qty_info['qty_label']}")
+        frappe.logger().debug(f"[iderp] Campi aggiornati per {tipo_vendita}: {qty_info['total_qty']:.3f} {qty_info['qty_label']}")
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore update campi: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore update campi: {str(e)}")
 
 def should_calculate_price(doc, item, qty_info):
     """
@@ -236,7 +236,7 @@ def should_calculate_price(doc, item, qty_info):
         return True
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore should_calculate_price: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore should_calculate_price: {str(e)}")
         return False
 
 def calculate_item_price_server_side(doc, item, tipo_vendita, qty_info):
@@ -292,10 +292,10 @@ def calculate_item_price_server_side(doc, item, tipo_vendita, qty_info):
             tipo_vendita, qty_info, pricing_info, price_per_unit, rate_unitario, customer
         )
         
-        frappe.logger().info(f"[IDERP] Prezzo calcolato server-side: {item.item_code} = €{rate_unitario:.2f}")
+        frappe.logger().info(f"[iderp] Prezzo calcolato server-side: {item.item_code} = €{rate_unitario:.2f}")
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore calcolo prezzo server-side: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore calcolo prezzo server-side: {str(e)}")
         item.note_calcolo = f"📊 {qty_info.get('dimensions', '')}\n❌ Errore calcolo prezzo: {str(e)}"
 
 def build_server_calculation_notes(tipo_vendita, qty_info, pricing_info, price_per_unit, rate_unitario, customer):
@@ -366,7 +366,7 @@ def recalculate_item_price(item):
             calculate_piece_price(item)
             
     except Exception as e:
-        frappe.logger().error(f"[IDERP Legacy] Errore ricalcolo prezzo: {str(e)}")
+        frappe.logger().error(f"[iderp Legacy] Errore ricalcolo prezzo: {str(e)}")
 
 def calculate_square_meter_price(item):
     """Calcola prezzo per vendita al metro quadrato - Legacy"""
@@ -407,7 +407,7 @@ def calculate_square_meter_price(item):
             item.note_calcolo = f"{mq_totali:.3f} m² (manca prezzo al m²)"
             
     except Exception as e:
-        frappe.logger().error(f"[IDERP Legacy] Errore calcolo m²: {str(e)}")
+        frappe.logger().error(f"[iderp Legacy] Errore calcolo m²: {str(e)}")
 
 def calculate_linear_meter_price(item):
     """Calcola prezzo per vendita al metro lineare - Legacy"""
@@ -442,7 +442,7 @@ def calculate_linear_meter_price(item):
             item.note_calcolo = f"{ml_totali:.2f} ml (manca prezzo al ml)"
             
     except Exception as e:
-        frappe.logger().error(f"[IDERP Legacy] Errore calcolo ml: {str(e)}")
+        frappe.logger().error(f"[iderp Legacy] Errore calcolo ml: {str(e)}")
 
 def calculate_piece_price(item):
     """Gestisce vendita al pezzo - Legacy"""
@@ -459,7 +459,7 @@ def calculate_piece_price(item):
             item.note_calcolo = "Vendita al pezzo - inserire prezzo unitario"
             
     except Exception as e:
-        frappe.logger().error(f"[IDERP Legacy] Errore calcolo pezzi: {str(e)}")
+        frappe.logger().error(f"[iderp Legacy] Errore calcolo pezzi: {str(e)}")
 
 # ================================
 # FUNZIONI UTILITY
@@ -496,7 +496,7 @@ def validate_measurements(item):
                 frappe.throw("Per vendita al metro lineare è richiesta la Lunghezza")
                 
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore validazione misure: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore validazione misure: {str(e)}")
 
 # ================================
 # DEBUG E TESTING

--- a/iderp/dashboard.py
+++ b/iderp/dashboard.py
@@ -1,6 +1,6 @@
 # iderp/dashboard.py
 """
-Dashboard functions per IDERP workspace in ERPNext 15
+Dashboard functions per iderp workspace in ERPNext 15
 Fornisce metriche e KPI per il sistema stampa digitale
 """
 
@@ -23,7 +23,7 @@ def get_quotations_this_month():
             "transaction_date": ["between", [first_day, last_day]]
         })
         
-        # Conta quotazioni IDERP (con tipo_vendita configurato)
+        # Conta quotazioni iderp (con tipo_vendita configurato)
         iderp_quotations = frappe.db.sql("""
             SELECT COUNT(DISTINCT q.name) as count
             FROM `tabQuotation` q
@@ -41,7 +41,7 @@ def get_quotations_this_month():
         return {
             "value": total_quotations,
             "label": _("Quotations This Month"),
-            "subtitle": f"{iderp_quotations} with IDERP, {confirmed_quotations} confirmed",
+            "subtitle": f"{iderp_quotations} with iderp, {confirmed_quotations} confirmed",
             "color": "#3498db",
             "trend": "up" if total_quotations > 0 else "neutral"
         }
@@ -110,7 +110,7 @@ def get_top_customer_groups():
 @frappe.whitelist()
 def get_configured_items_count():
     """
-    Ottieni numero item configurati per IDERP
+    Ottieni numero item configurati per iderp
     """
     try:
         # Item con misure personalizzate
@@ -225,7 +225,7 @@ def get_average_order_value():
 @frappe.whitelist()
 def get_iderp_system_health():
     """
-    Ottieni stato salute sistema IDERP
+    Ottieni stato salute sistema iderp
     """
     try:
         health_score = 0

--- a/iderp/doctype/customer_group_minimum/customer_group_minimum.json
+++ b/iderp/doctype/customer_group_minimum/customer_group_minimum.json
@@ -93,7 +93,7 @@
  "links": [],
  "modified": "2025-06-04 10:00:00.000000",
  "modified_by": "Administrator",
- "module": "IDERP",
+ "module": "iderp",
  "name": "Customer Group Minimum",
  "owner": "Administrator",
  "permissions": [

--- a/iderp/doctype/customer_group_price_rule/customer_group_price_rule.json
+++ b/iderp/doctype/customer_group_price_rule/customer_group_price_rule.json
@@ -133,7 +133,7 @@
  "links": [],
  "modified": "2025-06-04 10:00:00.000000",
  "modified_by": "Administrator",
- "module": "IDERP",
+ "module": "iderp",
  "name": "Customer Group Price Rule",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",

--- a/iderp/doctype/item_optional/item_optional.json
+++ b/iderp/doctype/item_optional/item_optional.json
@@ -62,7 +62,7 @@
  "links": [],
  "modified": "2025-01-01 00:00:00.000000",
  "modified_by": "Administrator",
- "module": "Iderp",
+ "module": "iderp",
  "name": "Item Optional",
  "naming_rule": "By fieldname",
  "owner": "Administrator",

--- a/iderp/doctype/item_optional/item_optional.py
+++ b/iderp/doctype/item_optional/item_optional.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, IDERP and contributors
+# Copyright (c) 2025, iderp and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/doctype/item_optional_applicability/item_optional_applicability.json
+++ b/iderp/doctype/item_optional_applicability/item_optional_applicability.json
@@ -37,7 +37,7 @@
  "links": [],
  "modified": "2025-01-01 00:00:00.000000",
  "modified_by": "Administrator",
- "module": "Iderp",
+ "module": "iderp",
  "name": "Item Optional Applicability",
  "owner": "Administrator",
  "permissions": [],

--- a/iderp/doctype/item_optional_applicability/item_optional_applicability.py
+++ b/iderp/doctype/item_optional_applicability/item_optional_applicability.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, IDERP and contributors
+# Copyright (c) 2025, iderp and contributors
 # For license information, please see license.txt
 
 from frappe.model.document import Document

--- a/iderp/doctype/item_pricing_tier/item_pricing_tier.json
+++ b/iderp/doctype/item_pricing_tier/item_pricing_tier.json
@@ -67,7 +67,7 @@
  "links": [],
  "modified": "2025-06-04 10:00:00.000000",
  "modified_by": "Administrator",
- "module": "IDERP",
+ "module": "iderp",
  "name": "Item Pricing Tier",
  "owner": "Administrator",
  "permissions": [

--- a/iderp/doctype/optional_template/optional_template.json
+++ b/iderp/doctype/optional_template/optional_template.json
@@ -46,7 +46,7 @@
  "links": [],
  "modified": "2025-01-01 00:00:00.000000",
  "modified_by": "Administrator",
- "module": "Iderp",
+ "module": "iderp",
  "name": "Optional Template",
  "owner": "Administrator",
  "permissions": [

--- a/iderp/doctype/optional_template/optional_template.py
+++ b/iderp/doctype/optional_template/optional_template.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, IDERP and contributors
+# Copyright (c) 2025, iderp and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/doctype/optional_template_item/optional_template_item.json
+++ b/iderp/doctype/optional_template_item/optional_template_item.json
@@ -40,7 +40,7 @@
  "links": [],
  "modified": "2025-01-01 00:00:00.000000",
  "modified_by": "Administrator",
- "module": "Iderp",
+ "module": "iderp",
  "name": "Optional Template Item",
  "owner": "Administrator",
  "permissions": [],

--- a/iderp/doctype/optional_template_item/optional_template_item.py
+++ b/iderp/doctype/optional_template_item/optional_template_item.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, IDERP and contributors
+# Copyright (c) 2025, iderp and contributors
 # For license information, please see license.txt
 
 from frappe.model.document import Document

--- a/iderp/doctype/sales_item_optional/sales_item_optional.json
+++ b/iderp/doctype/sales_item_optional/sales_item_optional.json
@@ -66,7 +66,7 @@
  "links": [],
  "modified": "2025-01-01 00:00:00.000000",
  "modified_by": "Administrator",
- "module": "Iderp",
+ "module": "iderp",
  "name": "Sales Item Optional",
  "owner": "Administrator",
  "permissions": [],

--- a/iderp/doctype/sales_item_optional/sales_item_optional.py
+++ b/iderp/doctype/sales_item_optional/sales_item_optional.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, IDERP and contributors
+# Copyright (c) 2025, iderp and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/emergency_disable.py
+++ b/iderp/emergency_disable.py
@@ -6,7 +6,7 @@ Script di emergenza per disabilitare custom fields problematici
 import frappe
 
 def disable_iderp_custom_fields():
-    """Disabilita temporaneamente tutti i custom fields IDERP"""
+    """Disabilita temporaneamente tutti i custom fields iderp"""
     
     # Custom fields che potrebbero causare problemi
     problematic_fields = [

--- a/iderp/global_minimums.py
+++ b/iderp/global_minimums.py
@@ -2,7 +2,7 @@
 
 """
 Modulo per gestione minimi globali per preventivo
-Sistema stampa digitale IDERP - ERPNext 15
+Sistema stampa digitale iderp - ERPNext 15
 Implementa logica minimi aggregati invece che per riga
 """
 

--- a/iderp/install.py
+++ b/iderp/install.py
@@ -1,7 +1,7 @@
 # iderp/install.py
 
 """
-Installazione completa IDERP per ERPNext 15
+Installazione completa iderp per ERPNext 15
 Sistema stampa digitale con pricing universale e customer groups
 VERSIONE FINALE OTTIMIZZATA E COMPLETA
 """
@@ -13,9 +13,9 @@ import json
 import os
 
 def after_install():
-    """Installazione completa plugin IDERP per ERPNext 15"""
+    """Installazione completa plugin iderp per ERPNext 15"""
     print("\n" + "="*80)
-    print("🚀 INSTALLAZIONE IDERP v2.0 - ERPNext 15 Compatible")
+    print("🚀 INSTALLAZIONE iderp v2.0 - ERPNext 15 Compatible")
     print("   Sistema Stampa Digitale - Versione Finale Completa")
     print("="*80)
     
@@ -76,7 +76,7 @@ def after_install():
         print("\n1️⃣3️⃣ Validazione installazione completa...")
         if validate_installation_complete():
             print("\n" + "="*80)
-            print("✅ INSTALLAZIONE IDERP COMPLETATA CON SUCCESSO!")
+            print("✅ INSTALLAZIONE iderp COMPLETATA CON SUCCESSO!")
             print("="*80)
             show_installation_summary_v15()
             show_next_steps()
@@ -625,7 +625,7 @@ def update_existing_field(field_name, new_config):
         return False
 
 def create_advanced_doctypes_v15():
-    """Crea DocTypes avanzati per sistema IDERP ERPNext 15"""
+    """Crea DocTypes avanzati per sistema iderp ERPNext 15"""
     
     # Verifica se DocTypes esistono già
     required_doctypes = [
@@ -935,7 +935,7 @@ def setup_demo_data_v15():
     
     print(f"   ✅ Demo data configurato:")
     print(f"      • {demo_items_created} item demo configurati")
-    print(f"      • Workspace IDERP: {'✅' if workspace_created else '❌'}")
+    print(f"      • Workspace iderp: {'✅' if workspace_created else '❌'}")
 
 def setup_demo_items():
     """Configura item demo con scaglioni"""
@@ -1041,12 +1041,12 @@ def setup_demo_pricing_tiers(item_doc):
         print(f"      ⚠️ Errore scaglioni demo: {e}")
 
 def setup_iderp_workspace():
-    """Configura workspace IDERP"""
+    """Configura workspace iderp"""
     
     try:
         # Il workspace viene configurato tramite config/desktop.py
         # Qui verifichiamo solo che sia tutto in ordine
-        print("      ✅ Workspace IDERP configurato via desktop.py")
+        print("      ✅ Workspace iderp configurato via desktop.py")
         return True
     except Exception as e:
         print(f"      ❌ Errore workspace: {e}")
@@ -1072,7 +1072,7 @@ def configure_system_settings():
         return False
 
 def setup_role_permissions():
-    """Configura permessi per ruoli IDERP"""
+    """Configura permessi per ruoli iderp"""
     
     # Permessi per Customer Group Price Rule
     setup_doctype_permissions("Customer Group Price Rule", [
@@ -1381,7 +1381,7 @@ def validate_portal_features():
 def show_installation_summary_v15():
     """Mostra riepilogo installazione per ERPNext 15"""
     
-    print("\n📋 RIEPILOGO INSTALLAZIONE IDERP v2.0:")
+    print("\n📋 RIEPILOGO INSTALLAZIONE iderp v2.0:")
     print("="*60)
     
     # Statistiche installazione
@@ -1456,7 +1456,7 @@ def show_next_steps():
     print("   • Verifica calcolo automatico prezzi")
     
     print("\n3. 🎛️ PERSONALIZZA:")
-    print("   • Workspace IDERP per dashboard")
+    print("   • Workspace iderp per dashboard")
     print("   • Report pricing analysis")
     print("   • Configura additional customer groups")
     
@@ -1547,7 +1547,7 @@ def create_optional_doctype():
         doctype_json = {
             "doctype": "DocType",
             "name": "Item Optional",
-            "module": "Iderp",
+            "module": "iderp",
             "custom": 1,
             "naming_rule": "By fieldname",
             "autoname": "field:optional_name",
@@ -1638,7 +1638,7 @@ def create_optional_applicability_doctype():
         doctype_json = {
             "doctype": "DocType",
             "name": "Item Optional Applicability",
-            "module": "Iderp",
+            "module": "iderp",
             "custom": 1,
             "istable": 1,
             "fields": [
@@ -1687,7 +1687,7 @@ def create_optional_template_doctype():
         doctype_json = {
             "doctype": "DocType",
             "name": "Optional Template",
-            "module": "Iderp",
+            "module": "iderp",
             "custom": 1,
             "fields": [
                 {
@@ -1753,7 +1753,7 @@ def create_optional_template_item_doctype():
         doctype_json = {
             "doctype": "DocType",
             "name": "Optional Template Item",
-            "module": "Iderp",
+            "module": "iderp",
             "custom": 1,
             "istable": 1,
             "fields": [
@@ -1841,7 +1841,7 @@ def create_sales_item_optional_doctype():
         doctype_json = {
             "doctype": "DocType",
             "name": "Sales Item Optional",
-            "module": "Iderp",
+            "module": "iderp",
             "custom": 1,
             "istable": 1,
             "fields": [
@@ -2299,8 +2299,8 @@ def generate_installation_report():
 
 # Comandi utility per console
 def quick_test():
-    """Test rapido sistema IDERP"""
-    print("\n🧪 TEST RAPIDO SISTEMA IDERP")
+    """Test rapido sistema iderp"""
+    print("\n🧪 TEST RAPIDO SISTEMA iderp")
     print("="*40)
     
     tests = {
@@ -2326,10 +2326,10 @@ def can_import_apis():
         return False
 
 def system_status():
-    """Mostra status dettagliato sistema IDERP"""
+    """Mostra status dettagliato sistema iderp"""
     stats = get_installation_stats()
     
-    print("\n📊 STATUS SISTEMA IDERP")
+    print("\n📊 STATUS SISTEMA iderp")
     print("="*40)
     print(f"DocTypes Custom: {stats['doctypes']}")
     print(f"Custom Fields: {stats['custom_fields']}")
@@ -2339,7 +2339,7 @@ def system_status():
     print(f"Regole Pricing: {stats['pricing_rules']}")
 
 def reinstall_iderp():
-    """Reinstalla completamente IDERP"""
+    """Reinstalla completamente iderp"""
     if frappe.utils.cint(input("\n⚠️  Sicuro di voler reinstallare? (1=Si, 0=No): ")):
         return after_install()
     return False

--- a/iderp/maintenance.py
+++ b/iderp/maintenance.py
@@ -1,7 +1,7 @@
 # iderp/maintenance.py
 
 """
-Modulo manutenzione e pulizia sistema IDERP
+Modulo manutenzione e pulizia sistema iderp
 Funzioni schedulabili per ottimizzazione performance
 """
 
@@ -51,23 +51,23 @@ def cleanup_old_calculations():
         # Log operazione
         frappe.log_error(
             "Pulizia calcoli completata",
-            "IDERP Maintenance"
+            "iderp Maintenance"
         )
         
     except Exception as e:
         frappe.log_error(
             f"Errore pulizia calcoli: {str(e)}",
-            "IDERP Maintenance Error"
+            "iderp Maintenance Error"
         )
 
 
 def cleanup_cache():
     """
-    Pulisce cache IDERP
+    Pulisce cache iderp
     Schedulato: weekly
     """
     try:
-        # Lista chiavi cache IDERP
+        # Lista chiavi cache iderp
         cache_keys = [
             "iderp_customer_pricing_cache",
             "iderp_item_tiers_cache",
@@ -97,19 +97,19 @@ def cleanup_cache():
         # Log operazione
         frappe.log_error(
             f"Cache pulita: {cleared_count} chiavi rimosse",
-            "IDERP Cache Cleanup"
+            "iderp Cache Cleanup"
         )
         
     except Exception as e:
         frappe.log_error(
             f"Errore pulizia cache: {str(e)}",
-            "IDERP Cache Error"
+            "iderp Cache Error"
         )
 
 
 def cleanup_document_cache():
     """
-    Pulisce cache documenti IDERP
+    Pulisce cache documenti iderp
     """
     # Pulisci cache per Item con misure personalizzate
     items = frappe.get_all("Item", 
@@ -124,7 +124,7 @@ def cleanup_document_cache():
 
 def optimize_database_tables():
     """
-    Ottimizza tabelle database IDERP
+    Ottimizza tabelle database iderp
     Schedulato: monthly (da aggiungere a hooks se necessario)
     """
     try:
@@ -148,13 +148,13 @@ def optimize_database_tables():
         
         frappe.log_error(
             "Ottimizzazione tabelle completata",
-            "IDERP Database Optimization"
+            "iderp Database Optimization"
         )
         
     except Exception as e:
         frappe.log_error(
             f"Errore ottimizzazione DB: {str(e)}",
-            "IDERP DB Error"
+            "iderp DB Error"
         )
 
 
@@ -193,13 +193,13 @@ def cleanup_orphaned_child_records():
     except Exception as e:
         frappe.log_error(
             f"Errore pulizia record orfani: {str(e)}",
-            "IDERP Cleanup Error"
+            "iderp Cleanup Error"
         )
 
 
 def validate_system_integrity():
     """
-    Valida integrità sistema IDERP
+    Valida integrità sistema iderp
     """
     issues = []
     
@@ -264,13 +264,13 @@ def validate_system_integrity():
         
         # Report risultati
         if issues:
-            report_content = "REPORT INTEGRITÀ SISTEMA IDERP\n" + "="*50 + "\n"
+            report_content = "REPORT INTEGRITÀ SISTEMA iderp\n" + "="*50 + "\n"
             for issue in issues:
                 report_content += f"\n[{issue['type'].upper()}] {issue['message']}"
             
             frappe.log_error(
                 report_content,
-                "IDERP System Integrity Check"
+                "iderp System Integrity Check"
             )
         
         return issues
@@ -278,7 +278,7 @@ def validate_system_integrity():
     except Exception as e:
         frappe.log_error(
             f"Errore validazione sistema: {str(e)}",
-            "IDERP Validation Error"
+            "iderp Validation Error"
         )
         return [{"type": "error", "message": str(e)}]
 
@@ -327,7 +327,7 @@ def run_maintenance_now(task=None):
 @frappe.whitelist()
 def get_system_health():
     """
-    Ottieni stato salute sistema IDERP
+    Ottieni stato salute sistema iderp
     """
     health_data = {
         "status": "healthy",
@@ -382,7 +382,7 @@ def get_system_health():
 
 def get_cache_size():
     """
-    Stima dimensione cache IDERP
+    Stima dimensione cache iderp
     """
     # Implementazione semplificata
     # In produzione potrebbe usare Redis INFO

--- a/iderp/optional_pricing.py
+++ b/iderp/optional_pricing.py
@@ -2,7 +2,7 @@
 
 """
 Modulo per gestione calcolo prezzi optional
-Sistema stampa digitale IDERP - ERPNext 15
+Sistema stampa digitale iderp - ERPNext 15
 """
 
 import frappe

--- a/iderp/overrides.py
+++ b/iderp/overrides.py
@@ -16,14 +16,14 @@ class CustomItem(Item):
     """
     
     def validate(self):
-        """Validazione estesa per Item con IDERP"""
+        """Validazione estesa per Item con iderp"""
         super().validate()
         self.validate_iderp_configuration()
         self.validate_pricing_tiers()
         self.validate_customer_group_minimums()
     
     def validate_iderp_configuration(self):
-        """Valida configurazione IDERP"""
+        """Valida configurazione iderp"""
         if not getattr(self, 'supports_custom_measurement', 0):
             return
             
@@ -64,7 +64,7 @@ class CustomItem(Item):
         self.clear_iderp_cache()
     
     def clear_iderp_cache(self):
-        """Pulisce cache IDERP per questo item"""
+        """Pulisce cache iderp per questo item"""
         # Pulisce cache pricing tiers
         from iderp.doctype.item_pricing_tier.item_pricing_tier import clear_all_pricing_tier_cache
         clear_all_pricing_tier_cache()
@@ -74,7 +74,7 @@ class CustomItem(Item):
         clear_all_minimum_cache()
     
     def get_iderp_summary(self):
-        """Ottieni riepilogo configurazione IDERP"""
+        """Ottieni riepilogo configurazione iderp"""
         if not getattr(self, 'supports_custom_measurement', 0):
             return {"configured": False}
             
@@ -97,16 +97,16 @@ class CustomItem(Item):
 
 class CustomQuotation(Quotation):
     """
-    Override della classe Quotation per calcoli IDERP
+    Override della classe Quotation per calcoli iderp
     """
     
     def validate(self):
-        """Validazione estesa per Quotation con IDERP"""
+        """Validazione estesa per Quotation con iderp"""
         super().validate()
         self.validate_iderp_items()
     
     def validate_iderp_items(self):
-        """Valida item con configurazione IDERP"""
+        """Valida item con configurazione iderp"""
         if not hasattr(self, 'items') or not self.items:
             return
             
@@ -114,7 +114,7 @@ class CustomQuotation(Quotation):
             self.validate_single_iderp_item(item)
     
     def validate_single_iderp_item(self, item):
-        """Valida singolo item IDERP"""
+        """Valida singolo item iderp"""
         tipo_vendita = getattr(item, 'tipo_vendita', 'Pezzo')
         
         # Validazioni specifiche per tipo
@@ -152,12 +152,12 @@ class CustomQuotation(Quotation):
         """Prima del salvataggio"""
         super().before_save()
         
-        # Applica calcoli IDERP se configurato
+        # Applica calcoli iderp se configurato
         if self.customer:
             self.apply_iderp_calculations()
     
     def apply_iderp_calculations(self):
-        """Applica calcoli IDERP server-side"""
+        """Applica calcoli iderp server-side"""
         try:
             # Import funzioni di calcolo
             from iderp.universal_pricing import apply_universal_pricing_server_side
@@ -171,11 +171,11 @@ class CustomQuotation(Quotation):
             
         except ImportError:
             # Fallback se moduli non disponibili
-            frappe.logger().warning("IDERP calculation modules not available, using basic calculations")
+            frappe.logger().warning("iderp calculation modules not available, using basic calculations")
             self.apply_basic_iderp_calculations()
     
     def apply_basic_iderp_calculations(self):
-        """Calcoli IDERP base di fallback"""
+        """Calcoli iderp base di fallback"""
         for item in self.items:
             tipo_vendita = getattr(item, 'tipo_vendita', 'Pezzo')
             
@@ -199,7 +199,7 @@ class CustomQuotation(Quotation):
 
 # Utility functions per override
 def get_item_iderp_config(item_code):
-    """Ottieni configurazione IDERP per item"""
+    """Ottieni configurazione iderp per item"""
     try:
         item_doc = frappe.get_doc("Item", item_code)
         if hasattr(item_doc, 'get_iderp_summary'):
@@ -209,12 +209,12 @@ def get_item_iderp_config(item_code):
         return {"configured": False}
 
 def validate_iderp_item_compatibility(doc, method=None):
-    """Hook di validazione compatibilità IDERP"""
+    """Hook di validazione compatibilità iderp"""
     if hasattr(doc, 'item_code') and doc.item_code:
         config = get_item_iderp_config(doc.item_code)
         
         if config.get("configured"):
-            # Item configurato per IDERP, applica validazioni
+            # Item configurato per iderp, applica validazioni
             tipo_vendita = getattr(doc, 'tipo_vendita', None)
             
             if not tipo_vendita:

--- a/iderp/patches/v2_0/add_metrature_custom_fields.py
+++ b/iderp/patches/v2_0/add_metrature_custom_fields.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/patches/v2_0/create_default_optional_templates.py
+++ b/iderp/patches/v2_0/create_default_optional_templates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/patches/v2_0/migrate_customer_group_prices.py
+++ b/iderp/patches/v2_0/migrate_customer_group_prices.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/patches/v2_0/migrate_to_erpnext_15.py
+++ b/iderp/patches/v2_0/migrate_to_erpnext_15.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/patches/v2_0/update_item_uom_settings.py
+++ b/iderp/patches/v2_0/update_item_uom_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/pricing.py
+++ b/iderp/pricing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2024, ID Studio and contributors
+# Copyright (c) 2024, idstudio and contributors
 # For license information, please see license.txt
 
 import frappe

--- a/iderp/pricing_utils.py
+++ b/iderp/pricing_utils.py
@@ -1,6 +1,6 @@
 # iderp/pricing_utils.py
 """
-Utility functions per gestione scaglioni prezzo IDERP
+Utility functions per gestione scaglioni prezzo iderp
 ERPNext 15 Compatible - Sistema Universale Metro Quadrato/Lineare/Pezzo
 """
 
@@ -20,7 +20,7 @@ def calculate_universal_item_pricing(item_code, tipo_vendita, base=0, altezza=0,
     """
     try:
         # Log della chiamata per debug
-        frappe.logger().info(f"[IDERP API] calculate_universal_item_pricing: {item_code}, {tipo_vendita}, customer={customer}")
+        frappe.logger().info(f"[iderp API] calculate_universal_item_pricing: {item_code}, {tipo_vendita}, customer={customer}")
         
         # Validazione parametri base
         if not item_code:
@@ -82,7 +82,7 @@ def calculate_universal_item_pricing(item_code, tipo_vendita, base=0, altezza=0,
         }
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP API] Errore calculate_universal_item_pricing: {str(e)}")
+        frappe.logger().error(f"[iderp API] Errore calculate_universal_item_pricing: {str(e)}")
         return {
             "error": f"Errore interno: {str(e)}",
             "success": False
@@ -102,7 +102,7 @@ def calculate_universal_item_pricing_with_fallback(item_code, tipo_vendita, base
             return result
         
         # Se fallisce, usa fallback hard-coded
-        frappe.logger().info(f"[IDERP FALLBACK] Usando prezzi hard-coded per {tipo_vendita}")
+        frappe.logger().info(f"[iderp FALLBACK] Usando prezzi hard-coded per {tipo_vendita}")
         
         # Calcola quantità
         qty_result = calculate_base_quantities_for_type(tipo_vendita, base, altezza, lunghezza, qty)
@@ -135,7 +135,7 @@ def calculate_universal_item_pricing_with_fallback(item_code, tipo_vendita, base
         }
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP FALLBACK] Errore: {str(e)}")
+        frappe.logger().error(f"[iderp FALLBACK] Errore: {str(e)}")
         return {"error": f"Errore fallback: {str(e)}", "success": False}
 
 @frappe.whitelist()
@@ -197,7 +197,7 @@ def get_item_pricing_tiers(item_code):
         }
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP API] Errore get_item_pricing_tiers: {str(e)}")
+        frappe.logger().error(f"[iderp API] Errore get_item_pricing_tiers: {str(e)}")
         return {"error": f"Errore caricamento scaglioni: {str(e)}"}
 
 @frappe.whitelist()
@@ -242,7 +242,7 @@ def get_customer_group_min_sqm(customer, item_code):
         }
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP API] Errore get_customer_group_min_sqm: {str(e)}")
+        frappe.logger().error(f"[iderp API] Errore get_customer_group_min_sqm: {str(e)}")
         return {"min_sqm": 0, "error": str(e)}
 
 # ================================
@@ -377,7 +377,7 @@ def get_item_pricing_for_type(item_code, tipo_vendita, quantity):
         return None
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore get_item_pricing_for_type: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore get_item_pricing_for_type: {str(e)}")
         return None
 
 def get_customer_specific_pricing_for_type(customer, item_code, tipo_vendita, quantity):
@@ -410,7 +410,7 @@ def get_customer_specific_pricing_for_type(customer, item_code, tipo_vendita, qu
                         effective_qty = min_qty
                         minimum_applied = True
                         minimum_config = min_rule
-                        frappe.logger().info(f"[IDERP] Minimo applicato {tipo_vendita}: {quantity:.3f} → {effective_qty:.3f}")
+                        frappe.logger().info(f"[iderp] Minimo applicato {tipo_vendita}: {quantity:.3f} → {effective_qty:.3f}")
                     break
         
         # Usa quantità effettiva per trovare prezzo
@@ -429,7 +429,7 @@ def get_customer_specific_pricing_for_type(customer, item_code, tipo_vendita, qu
         return standard_price
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore customer specific pricing: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore customer specific pricing: {str(e)}")
         return get_item_pricing_for_type(item_code, tipo_vendita, quantity)
 
 def get_hardcoded_fallback_pricing(tipo_vendita, quantity):
@@ -470,7 +470,7 @@ def get_hardcoded_fallback_pricing(tipo_vendita, quantity):
         return None
         
     except Exception as e:
-        frappe.logger().error(f"[IDERP] Errore fallback pricing: {str(e)}")
+        frappe.logger().error(f"[iderp] Errore fallback pricing: {str(e)}")
         return None
 
 def build_calculation_notes(tipo_vendita, qty_result, pricing_info, price_per_unit, rate_unitario):

--- a/iderp/public/js/ecommerce_calculator.js
+++ b/iderp/public/js/ecommerce_calculator.js
@@ -1,5 +1,5 @@
 // iderp/public/js/ecommerce_calculator.js
-console.log("IDERP: E-commerce Calculator Loaded");
+console.log("iderp: E-commerce Calculator Loaded");
 
 class ERPProductCalculator {
     constructor(itemCode) {

--- a/iderp/public/js/item_config.js
+++ b/iderp/public/js/item_config.js
@@ -1,19 +1,19 @@
 // iderp/public/js/item_config.js
-// IDERP Item Configuration for ERPNext 15
+// iderp Item Configuration for ERPNext 15
 // Enhanced version with proper validation and UX
 
-console.log("IDERP: Item Config JS Loading - ERPNext 15 Compatible");
+console.log("iderp: Item Config JS Loading - ERPNext 15 Compatible");
 
 frappe.ui.form.on('Item', {
     refresh: function(frm) {
-        console.log("IDERP: Item form refreshed");
+        console.log("iderp: Item form refreshed");
         
-        // Add custom buttons for IDERP configuration
+        // Add custom buttons for iderp configuration
         if (frm.doc.supports_custom_measurement) {
             add_iderp_buttons(frm);
         }
         
-        // Show IDERP status indicator
+        // Show iderp status indicator
         update_iderp_status_indicator(frm);
         
         // Add help messages
@@ -21,10 +21,10 @@ frappe.ui.form.on('Item', {
     },
     
     supports_custom_measurement: function(frm) {
-        console.log("IDERP: Custom measurement toggled:", frm.doc.supports_custom_measurement);
+        console.log("iderp: Custom measurement toggled:", frm.doc.supports_custom_measurement);
         
         if (frm.doc.supports_custom_measurement) {
-            // Enable IDERP features
+            // Enable iderp features
             enable_iderp_features(frm);
             
             // Set default selling type if not set
@@ -35,7 +35,7 @@ frappe.ui.form.on('Item', {
             // Show configuration guide
             show_iderp_setup_guide(frm);
         } else {
-            // Disable IDERP features
+            // Disable iderp features
             disable_iderp_features(frm);
         }
         
@@ -46,7 +46,7 @@ frappe.ui.form.on('Item', {
     
     tipo_vendita_default: function(frm) {
         if (frm.doc.supports_custom_measurement && frm.doc.tipo_vendita_default) {
-            console.log("IDERP: Default selling type changed to:", frm.doc.tipo_vendita_default);
+            console.log("iderp: Default selling type changed to:", frm.doc.tipo_vendita_default);
             
             // Update help text based on selling type
             update_selling_type_help(frm);
@@ -66,8 +66,8 @@ frappe.ui.form.on('Item', {
 function add_iderp_buttons(frm) {
     // Remove existing buttons first
     frm.page.remove_inner_button('Configure Pricing Tiers');
-    frm.page.remove_inner_button('Test IDERP Calculation');
-    frm.page.remove_inner_button('IDERP Summary');
+    frm.page.remove_inner_button('Test iderp Calculation');
+    frm.page.remove_inner_button('iderp Summary');
     
     // Add configuration button
     frm.page.add_inner_button(__('Configure Pricing Tiers'), function() {
@@ -75,12 +75,12 @@ function add_iderp_buttons(frm) {
     });
     
     // Add test calculation button
-    frm.page.add_inner_button(__('Test IDERP Calculation'), function() {
+    frm.page.add_inner_button(__('Test iderp Calculation'), function() {
         open_test_calculation_dialog(frm);
     });
     
     // Add summary button
-    frm.page.add_inner_button(__('IDERP Summary'), function() {
+    frm.page.add_inner_button(__('iderp Summary'), function() {
         show_iderp_summary(frm);
     });
 }
@@ -89,15 +89,15 @@ function update_iderp_status_indicator(frm) {
     let status = get_iderp_configuration_status(frm);
     
     let color = 'red';
-    let message = 'IDERP Not Configured';
+    let message = 'iderp Not Configured';
     
     if (status.configured) {
         if (status.complete) {
             color = 'green';
-            message = `IDERP Configured: ${status.summary}`;
+            message = `iderp Configured: ${status.summary}`;
         } else {
             color = 'orange';
-            message = `IDERP Partial: ${status.summary}`;
+            message = `iderp Partial: ${status.summary}`;
         }
     }
     
@@ -139,7 +139,7 @@ function get_iderp_configuration_status(frm) {
 }
 
 function enable_iderp_features(frm) {
-    // Show IDERP sections
+    // Show iderp sections
     frm.toggle_display(['pricing_section', 'customer_group_minimums_section'], true);
     
     // Enable fields
@@ -150,7 +150,7 @@ function enable_iderp_features(frm) {
 }
 
 function disable_iderp_features(frm) {
-    // Hide IDERP sections
+    // Hide iderp sections
     frm.toggle_display(['pricing_section', 'customer_group_minimums_section'], false);
     
     // Clear required flags
@@ -161,7 +161,7 @@ function disable_iderp_features(frm) {
 }
 
 function add_iderp_styling(frm) {
-    // Add visual indicators for IDERP sections
+    // Add visual indicators for iderp sections
     setTimeout(function() {
         let sections = frm.fields_dict.pricing_section?.$wrapper;
         if (sections) {
@@ -172,7 +172,7 @@ function add_iderp_styling(frm) {
 
 function show_iderp_setup_guide(frm) {
     frappe.msgprint({
-        title: __('IDERP Configuration Guide'),
+        title: __('iderp Configuration Guide'),
         indicator: 'blue',
         message: `
             <div class="iderp-setup-guide">
@@ -212,7 +212,7 @@ function update_selling_type_help(frm) {
 function validate_iderp_configuration(frm) {
     // Validate that configuration makes sense
     if (!frm.doc.tipo_vendita_default) {
-        frappe.msgprint(__('Please select a Default Selling Type for IDERP configuration'));
+        frappe.msgprint(__('Please select a Default Selling Type for iderp configuration'));
         return false;
     }
     
@@ -252,7 +252,7 @@ function open_pricing_tiers_dialog(frm) {
 
 function open_test_calculation_dialog(frm) {
     let dialog = new frappe.ui.Dialog({
-        title: __('Test IDERP Calculation'),
+        title: __('Test iderp Calculation'),
         fields: [
             {
                 fieldtype: 'Select',
@@ -353,7 +353,7 @@ function show_iderp_summary(frm) {
         callback: function(r) {
             let summary_html = `
                 <div class="iderp-summary">
-                    <h4>IDERP Configuration Summary</h4>
+                    <h4>iderp Configuration Summary</h4>
                     <table class="table table-bordered">
                         <tr><td><strong>Item Code:</strong></td><td>${frm.doc.item_code}</td></tr>
                         <tr><td><strong>Supports Custom Measurement:</strong></td><td>${frm.doc.supports_custom_measurement ? '✅ Yes' : '❌ No'}</td></tr>
@@ -366,7 +366,7 @@ function show_iderp_summary(frm) {
             `;
             
             frappe.msgprint({
-                title: __('IDERP Summary'),
+                title: __('iderp Summary'),
                 message: summary_html
             });
         }
@@ -389,7 +389,7 @@ function add_iderp_help_messages(frm) {
     }
 }
 
-// Utility function for IDERP styling
+// Utility function for iderp styling
 function add_iderp_css() {
     if ($('.iderp-style').length === 0) {
         $('head').append(`
@@ -414,8 +414,8 @@ function add_iderp_css() {
     }
 }
 
-// Initialize IDERP styling
+// Initialize iderp styling
 $(document).ready(function() {
     add_iderp_css();
-    console.log("✅ IDERP Item Config loaded for ERPNext 15");
+    console.log("✅ iderp Item Config loaded for ERPNext 15");
 });

--- a/iderp/public/js/item_dimension.js
+++ b/iderp/public/js/item_dimension.js
@@ -1,6 +1,6 @@
-// IDERP - Sistema Calcolatore Universale ERPNext 15 Compatible
+// iderp - Sistema Calcolatore Universale ERPNext 15 Compatible
 // Versione 2.0 - Supporta Metro Quadrato, Metro Lineare, Pezzo + Customer Groups
-console.log("IDERP v2.0: Loading Universal Calculator for ERPNext 15");
+console.log("iderp v2.0: Loading Universal Calculator for ERPNext 15");
 
 // Variabili globali per controllo stato
 var iderp_calculating = false;
@@ -26,7 +26,7 @@ function calculate_universal_pricing_v15(frm, cdt, cdn, force_recalc = false) {
     
     // Non ricalcolare se bloccato (a meno che non sia forzato)
     if (row.price_locked && !force_recalc) {
-        console.log(`IDERP: Riga ${row.idx} bloccata, skip calcolo`);
+        console.log(`iderp: Riga ${row.idx} bloccata, skip calcolo`);
         return;
     }
     
@@ -132,7 +132,7 @@ function calculate_base_quantities_v15(row, tipo_vendita) {
         return null;
         
     } catch (e) {
-        console.error("IDERP: Errore calcolo quantità", e);
+        console.error("iderp: Errore calcolo quantità", e);
         return null;
     }
 }
@@ -214,7 +214,7 @@ function call_pricing_api_v15(frm, row, tipo_vendita, qty_info) {
                     });
                 }
             } catch (err) {
-                console.error("IDERP: Errore callback", err);
+                console.error("iderp: Errore callback", err);
                 row.note_calcolo = `📊 ${qty_info.display_text}\n💥 Errore interno calcolo`;
                 frm.refresh_field("items");
             } finally {
@@ -223,7 +223,7 @@ function call_pricing_api_v15(frm, row, tipo_vendita, qty_info) {
             }
         },
         error: function(err) {
-            console.error("IDERP: Errore API", err);
+            console.error("iderp: Errore API", err);
             row.note_calcolo = `📊 ${qty_info.display_text}\n🔌 Errore connessione API`;
             frm.refresh_field("items");
             iderp_calculating = false;
@@ -243,7 +243,7 @@ function call_pricing_api_v15(frm, row, tipo_vendita, qty_info) {
 
 function update_toolbar_status_v15(frm) {
     if (!selected_item_row) {
-        frm.page.set_indicator("🎛️ IDERP: Seleziona riga per controlli", "blue");
+        frm.page.set_indicator("🎛️ iderp: Seleziona riga per controlli", "blue");
         return;
     }
     
@@ -388,7 +388,7 @@ frappe.ui.form.on('Quotation Item', {
     tipo_vendita: function(frm, cdt, cdn) {
         let row = locals[cdt][cdn];
         
-        console.log(`IDERP: Tipo vendita cambiato in: ${row.tipo_vendita}`);
+        console.log(`iderp: Tipo vendita cambiato in: ${row.tipo_vendita}`);
         
         // Reset campi quando cambia tipo
         reset_measurement_fields(row);
@@ -560,7 +560,7 @@ function handle_measurement_change(frm, cdt, cdn, changed_field) {
     }
     
     // Log del cambiamento
-    console.log(`IDERP: Campo ${changed_field} cambiato, tipo: ${row.tipo_vendita}`);
+    console.log(`iderp: Campo ${changed_field} cambiato, tipo: ${row.tipo_vendita}`);
     
     // Aggiorna campi calcolati sempre
     let qty_info = calculate_base_quantities_v15(row, row.tipo_vendita);
@@ -586,7 +586,7 @@ $(document).on('click', '[data-fieldname="items"] .grid-row', function() {
             if (item) {
                 selected_item_row = item;
                 update_toolbar_status_v15(cur_frm);
-                console.log(`IDERP: Riga selezionata: ${item.item_code} (${item.tipo_vendita})`);
+                console.log(`iderp: Riga selezionata: ${item.item_code} (${item.tipo_vendita})`);
             }
         }
     }, 100);
@@ -594,6 +594,6 @@ $(document).on('click', '[data-fieldname="items"] .grid-row', function() {
 
 // Inizializzazione
 $(document).ready(function() {
-    console.log("✅ IDERP v2.0: Universal Calculator caricato per ERPNext 15");
+    console.log("✅ iderp v2.0: Universal Calculator caricato per ERPNext 15");
     console.log("🎯 Supporto: Metro Quadrato, Metro Lineare, Pezzo + Customer Groups");
 });

--- a/iderp/reports.py
+++ b/iderp/reports.py
@@ -1,7 +1,7 @@
 # iderp/reports.py
 
 """
-Modulo report e analisi IDERP
+Modulo report e analisi iderp
 Report settimanali e analisi dati stampa digitale
 """
 
@@ -56,13 +56,13 @@ def generate_weekly_reports():
         
         frappe.log_error(
             f"Report settimanale generato: {start_date} - {end_date}",
-            "IDERP Weekly Report"
+            "iderp Weekly Report"
         )
         
     except Exception as e:
         frappe.log_error(
             f"Errore generazione report: {str(e)}",
-            "IDERP Report Error"
+            "iderp Report Error"
         )
 
 
@@ -412,9 +412,9 @@ def save_weekly_report(reports):
     """
     try:
         # Crea documento Report Log (se esiste il DocType)
-        if frappe.db.exists("DocType", "IDERP Report Log"):
+        if frappe.db.exists("DocType", "iderp Report Log"):
             report_doc = frappe.get_doc({
-                "doctype": "IDERP Report Log",
+                "doctype": "iderp Report Log",
                 "report_type": "Weekly Summary",
                 "period_start": reports["period"]["start"],
                 "period_end": reports["period"]["end"],
@@ -462,7 +462,7 @@ def send_weekly_report_email(reports):
         # Invia email
         frappe.sendmail(
             recipients=recipients,
-            subject=f"IDERP Report Settimanale - {reports['period']['start']} / {reports['period']['end']}",
+            subject=f"iderp Report Settimanale - {reports['period']['start']} / {reports['period']['end']}",
             message=html_content,
             delayed=False
         )
@@ -491,7 +491,7 @@ def generate_html_report(reports):
     </head>
     <body>
         <div class="header">
-            <h1>IDERP Report Settimanale</h1>
+            <h1>iderp Report Settimanale</h1>
             <p>Periodo: {reports['period']['start']} - {reports['period']['end']}</p>
         </div>
     """
@@ -614,6 +614,6 @@ def get_report_list():
         {
             "name": "performance",
             "title": _("Report Performance"),
-            "description": _("Performance sistema IDERP")
+            "description": _("Performance sistema iderp")
         }
     ]

--- a/iderp/server_side_minimums.py
+++ b/iderp/server_side_minimums.py
@@ -201,8 +201,8 @@ def disable_problematic_javascript():
     Crea file JavaScript vuoto per disabilitare eventi problematici
     """
     js_content = '''
-// IDERP: JavaScript Disabilitato - Solo Server-Side
-console.log("IDERP: JavaScript events disabilitati - calcoli solo server-side");
+// iderp: JavaScript Disabilitato - Solo Server-Side
+console.log("iderp: JavaScript events disabilitati - calcoli solo server-side");
 
 // Nessun evento JavaScript sui campi rate
 // Tutto gestito lato server per evitare loop infiniti
@@ -230,7 +230,7 @@ frappe.ui.form.on('Quotation', {
     }
 });
 
-console.log("✅ IDERP: Modalità server-side attiva");
+console.log("✅ iderp: Modalità server-side attiva");
 '''
     
     return js_content

--- a/iderp/setup_commands.py
+++ b/iderp/setup_commands.py
@@ -1,7 +1,7 @@
 # iderp/setup_commands.py
 
 """
-Comandi console per setup e manutenzione IDERP
+Comandi console per setup e manutenzione iderp
 Uso: bench --site sito.local console
      > from iderp.setup_commands import *
 """
@@ -31,8 +31,8 @@ def qh():
 # Comandi principali
 
 def quick_test():
-    """Test rapido integrità sistema IDERP"""
-    print("\n🧪 TEST RAPIDO SISTEMA IDERP")
+    """Test rapido integrità sistema iderp"""
+    print("\n🧪 TEST RAPIDO SISTEMA iderp")
     print("="*50)
     
     tests = {
@@ -60,7 +60,7 @@ def quick_test():
     print(f"RISULTATO: {passed} passati, {failed} falliti")
     
     if failed == 0:
-        print("✅ SISTEMA IDERP OPERATIVO!")
+        print("✅ SISTEMA iderp OPERATIVO!")
     else:
         print("⚠️ SISTEMA RICHIEDE ATTENZIONE")
     
@@ -221,12 +221,12 @@ def test_javascript_files():
 
 def system_status():
     """Mostra status dettagliato sistema"""
-    print("\n📊 STATUS SISTEMA IDERP")
+    print("\n📊 STATUS SISTEMA iderp")
     print("="*50)
     
     # Versione
     from iderp import __version__
-    print(f"📌 Versione IDERP: {__version__}")
+    print(f"📌 Versione iderp: {__version__}")
     print(f"📌 Frappe: {frappe.__version__}")
     
     try:
@@ -261,7 +261,7 @@ def system_status():
         print(f"  {icon} {check}: {data['value']}")
     
     # Ultimi errori
-    print("\n🐛 ULTIMI ERRORI IDERP:")
+    print("\n🐛 ULTIMI ERRORI iderp:")
     recent_errors = frappe.get_all("Error Log",
         filters={
             "method": ["like", "%iderp%"],
@@ -307,8 +307,8 @@ def get_installation_stats():
     return stats
 
 def reinstall_iderp():
-    """Reinstalla IDERP con conferma"""
-    print("\n⚠️  ATTENZIONE: Reinstallazione IDERP")
+    """Reinstalla iderp con conferma"""
+    print("\n⚠️  ATTENZIONE: Reinstallazione iderp")
     print("="*50)
     print("Questo comando:")
     print("• Ricreerà tutti i campi custom")
@@ -343,18 +343,18 @@ def reinstall_iderp():
 
 def show_help():
     """Mostra comandi disponibili"""
-    print("\n📚 COMANDI IDERP DISPONIBILI")
+    print("\n📚 COMANDI iderp DISPONIBILI")
     print("="*50)
     
     commands = [
         ("qt()", "Quick Test", "Test rapido integrità sistema"),
         ("qs()", "Quick Status", "Mostra status dettagliato"),
-        ("qi()", "Quick Install", "Reinstalla IDERP"),
+        ("qi()", "Quick Install", "Reinstalla iderp"),
         ("qh()", "Quick Help", "Mostra questo help"),
         ("", "", ""),
         ("setup_demo_data()", "Setup Demo", "Crea dati demo aggiuntivi"),
         ("fix_permissions()", "Fix Permessi", "Sistema permessi DocTypes"),
-        ("clear_iderp_cache()", "Clear Cache", "Pulisce cache IDERP"),
+        ("clear_iderp_cache()", "Clear Cache", "Pulisce cache iderp"),
         ("run_maintenance()", "Manutenzione", "Esegue manutenzione manuale"),
         ("test_pricing()", "Test Pricing", "Test calcolo prezzi"),
         ("export_config()", "Export Config", "Esporta configurazione"),
@@ -436,7 +436,7 @@ def setup_demo_data():
     frappe.db.commit()
 
 def fix_permissions():
-    """Sistema permessi DocTypes IDERP"""
+    """Sistema permessi DocTypes iderp"""
     print("\n🔐 FIX PERMESSI DOCTYPES")
     print("="*50)
     
@@ -478,8 +478,8 @@ def fix_permissions():
     frappe.clear_cache()
 
 def clear_iderp_cache():
-    """Pulisce tutta la cache IDERP"""
-    print("\n🧹 PULIZIA CACHE IDERP")
+    """Pulisce tutta la cache iderp"""
+    print("\n🧹 PULIZIA CACHE iderp")
     print("="*50)
     
     from iderp.maintenance import cleanup_cache
@@ -503,7 +503,7 @@ def clear_iderp_cache():
 
 def run_maintenance(task=None):
     """Esegue task manutenzione"""
-    print("\n🔧 MANUTENZIONE SISTEMA IDERP")
+    print("\n🔧 MANUTENZIONE SISTEMA iderp")
     print("="*50)
     
     if not task:
@@ -556,11 +556,11 @@ def test_pricing(item_code="POSTER-A3", customer_group="Gold", base=50, altezza=
         traceback.print_exc()
 
 def export_config(filename=None):
-    """Esporta configurazione IDERP"""
+    """Esporta configurazione iderp"""
     if not filename:
         filename = f"iderp_config_{frappe.utils.today()}.json"
     
-    print(f"\n📤 EXPORT CONFIGURAZIONE IDERP")
+    print(f"\n📤 EXPORT CONFIGURAZIONE iderp")
     print("="*50)
     
     config = {
@@ -608,8 +608,8 @@ def export_config(filename=None):
     return file_path
 
 def import_config(filename):
-    """Importa configurazione IDERP"""
-    print(f"\n📥 IMPORT CONFIGURAZIONE IDERP")
+    """Importa configurazione iderp"""
+    print(f"\n📥 IMPORT CONFIGURAZIONE iderp")
     print("="*50)
     
     file_path = frappe.get_site_path("private/files", filename)
@@ -634,5 +634,5 @@ def import_config(filename):
         return False
 
 # Auto-esegui help al primo import
-print("\n🚀 IDERP Setup Commands caricati!")
+print("\n🚀 iderp Setup Commands caricati!")
 print("Digita qh() per vedere tutti i comandi disponibili")

--- a/info-id.md
+++ b/info-id.md
@@ -36,11 +36,11 @@ cd ~/frappe-bench
 cat > update_iderp.sh << 'EOF'
 #!/bin/bash
 
-# Script aggiornamento IDERP per ERPNext 15
+# Script aggiornamento iderp per ERPNext 15
 # Versione: 2.0 - Compatibile ERPNext 15
 
 echo "🚀 =========================================="
-echo "    AGGIORNAMENTO PLUGIN IDERP v2.0"
+echo "    AGGIORNAMENTO PLUGIN iderp v2.0"
 echo "    Compatibile ERPNext 15"
 echo "=========================================="
 
@@ -247,7 +247,7 @@ Se puoi evita di farmi usare la console e usa i file per installare o aggiornare
 
 
 
-# Roadmap Implementazione IDERP - Sistema Stampa Digitale
+# Roadmap Implementazione iderp - Sistema Stampa Digitale
 
 ## ✅ **FASE 1 COMPLETATA: Customer Group Pricing (Completato Giugno 2025)**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.0.0"
 description = "Custom ERPNext App per gestione prodotti a metratura e sincronizzazione documenti"
 readme = "README.md"
 authors = [
-    {name = "ID Studio", email = "info@idstudio.it"}
+    {name = "idstudio", email = "dev@idstudio.org"}
 ]
 license = {text = "MIT"}
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# IDERP Requirements for ERPNext 15
+# iderp Requirements for ERPNext 15
 # Core dependencies
 
 # Frappe Framework (ERPNext 15 compatible)
@@ -57,7 +57,7 @@ email-validator>=1.1.0
 # Performance monitoring (optional)
 # psutil>=5.8.0
 
-# Additional utilities for IDERP specific features
+# Additional utilities for iderp specific features
 # For mathematical calculations in pricing
 sympy>=1.8
 
@@ -76,10 +76,10 @@ structlog>=21.0.0
 # Note: ERPNext 15 compatibility
 # - Ensure all packages are compatible with Python 3.8+
 # - Frappe 15.x includes many dependencies automatically
-# - Only add what's specifically needed for IDERP features
+# - Only add what's specifically needed for iderp features
 # - Test compatibility before adding new packages
 
-# IDERP specific calculation engines
+# iderp specific calculation engines
 # (Custom packages would go here if we had any)
 
 # Version pins for stability in production

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # setup.py
 """
-IDERP Setup Configuration for ERPNext 15
+iderp Setup Configuration for ERPNext 15
 Sistema Stampa Digitale - Package Installation
 """
 
@@ -27,7 +27,7 @@ setup(
     # Metadata
     description="Sistema completo per stampa digitale con calcoli automatici Metro Quadrato/Lineare/Pezzo",
     long_description="""
-IDERP - Sistema Stampa Digitale per ERPNext 15
+iderp - Sistema Stampa Digitale per ERPNext 15
 
 Funzionalità principali:
 - Vendita multi-unità: Metro Quadrato, Metro Lineare, Pezzo
@@ -42,10 +42,10 @@ Perfetto per aziende di stampa digitale, serigrafia, cartotecnica.
     long_description_content_type="text/plain",
     
     # Author info
-    author="idstudio AI",
-    author_email="ai@idstudio.org",
-    maintainer="idstudio AI",
-    maintainer_email="ai@idstudio.org",
+    author="idstudio",
+    author_email="dev@idstudio.org",
+    maintainer="idstudio",
+    maintainer_email="dev@idstudio.org",
     
     # URLs
     url="https://github.com/haringk/iderp2",
@@ -138,10 +138,10 @@ Perfetto per aziende di stampa digitale, serigrafia, cartotecnica.
     
     # Additional metadata for ERPNext 15
     app_name="iderp",
-    app_title="IDERP - Sistema Stampa Digitale",
-    app_publisher="idstudio AI",
+    app_title="iderp - Sistema Stampa Digitale",
+    app_publisher="idstudio",
     app_description="Plugin ERPNext per stampa digitale con calcoli universali",
-    app_email="ai@idstudio.org",
+    app_email="dev@idstudio.org",
     app_license="MIT",
     app_version="2.0.0",
     required_apps=["frappe", "erpnext"],
@@ -172,17 +172,17 @@ Perfetto per aziende di stampa digitale, serigrafia, cartotecnica.
 
 # Post-install message
 print("""
-🎉 IDERP v2.0.0 Setup Complete!
+🎉 iderp v2.0.0 Setup Complete!
 
 📋 Next Steps:
 1. Install: bench --site [site-name] install-app iderp
-2. Setup: Go to IDERP workspace to configure
+2. Setup: Go to iderp workspace to configure
 3. Configure: Set up Customer Groups and Item pricing
 4. Test: Create a quotation with custom measurements
 
 📖 Documentation: https://github.com/haringk/iderp2
 🐛 Issues: https://github.com/haringk/iderp2/issues
-📧 Support: ai@idstudio.org
+📧 Support: dev@idstudio.org
 
 ERPNext 15 Compatible ✅
 """)


### PR DESCRIPTION
## Summary
- standardize plugin and author references to lowercase `iderp`
- set all author fields to `idstudio` with `dev@idstudio.org`
- remove mixed casing from documentation and source

## Testing
- `ruff check iderp/__init__.py | head -n 20`
- `black --check iderp/__init__.py`
- `python -m compileall -q iderp`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_6841ea1e052c83289e4fff826ab8503b