### PR TITLE
Fix iderp_module initialization

### DIFF
--- a/iderp_module/__init__.py
+++ b/iderp_module/__init__.py
@@ -1,1 +1,2 @@
-# iderp_module package
+"""Inizializzazione pacchetto iderp_module"""
+__version__ = "2.0.0"


### PR DESCRIPTION
## Summary
- clean up `iderp_module/__init__.py` and set a static version

## Testing
- `python -m pip check`
- `pytest -q`
- `python -c 'import iderp_module; print(iderp_module.__version__)'`

------
https://chatgpt.com/codex/tasks/task_b_6859132430a483288d563b42d22832d2